### PR TITLE
Fix php7 fatal errors

### DIFF
--- a/pchart/class/pData.class.php
+++ b/pchart/class/pData.class.php
@@ -66,9 +66,8 @@
                         "7"=>array("R"=>224,"G"=>176,"B"=>46,"Alpha"=>100));
 
    /* Class creator */
-   function pData()
-    {
-     $this->Data = "";
+   function pData() {
+     $this->Data = [];
      $this->Data["XAxisDisplay"]	= AXIS_FORMAT_DEFAULT;
      $this->Data["XAxisFormat"]		= NULL;
      $this->Data["XAxisName"]		= NULL;
@@ -76,7 +75,7 @@
      $this->Data["Abscissa"]		= NULL;
      $this->Data["AbsicssaPosition"]	= AXIS_POSITION_BOTTOM;
 
-     $this->Data["Axis"][0]["Display"]  = AXIS_FORMAT_DEFAULT;
+     $this->Data["Axis"][0]["Display"] = AXIS_FORMAT_DEFAULT;
      $this->Data["Axis"][0]["Position"] = AXIS_POSITION_LEFT;
      $this->Data["Axis"][0]["Identity"] = AXIS_Y;
     }
@@ -264,7 +263,7 @@
 
    /* Mark all series as drawable */
    function drawAll()
-    { foreach($this->Data["Series"] as $Key => $Value) { if ( $this->Data["Abscissa"] != $Key ) { $this->Data["Series"][$Key]["isDrawable"]=TRUE; } } }    
+    { foreach($this->Data["Series"] as $Key => $Value) { if ( $this->Data["Abscissa"] != $Key ) { $this->Data["Series"][$Key]["isDrawable"]=TRUE; } } }
 
    /* Return the average value of the given serie */
    function getSerieAverage($Serie)
@@ -605,7 +604,7 @@
        $this->Data["Series"][$Serie]["Color"]["Alpha"] = 100;
       }
     }
-     
+
    function normalize($NormalizationFactor=100,$UnitChange=NULL,$Round=1)
     {
      $Abscissa = $this->Data["Abscissa"];
@@ -774,14 +773,14 @@
 
    /* Convert a string to a single elements array */
    function convertToArray($Value)
-    { $Values = ""; $Values[] = $Value; return($Values); }
+    { $Values = []; $Values[] = $Value; return($Values); }
 
    /* Class string wrapper */
    function __toString()
     { return("pData object."); }
 
-   function left($value,$NbChar)	{ return substr($value,0,$NbChar); }  
-   function right($value,$NbChar)	{ return substr($value,strlen($value)-$NbChar,$NbChar); }  
-   function mid($value,$Depart,$NbChar)	{ return substr($value,$Depart-1,$NbChar); }  
+   function left($value,$NbChar)	{ return substr($value,0,$NbChar); }
+   function right($value,$NbChar)	{ return substr($value,strlen($value)-$NbChar,$NbChar); }
+   function mid($value,$Depart,$NbChar)	{ return substr($value,$Depart-1,$NbChar); }
   }
 ?>

--- a/pchart/class/pDraw.class.php
+++ b/pchart/class/pDraw.class.php
@@ -140,7 +140,7 @@
      $SkipX		= isset($Format["SkipX"]) ? $Format["SkipX"] : OUT_OF_SIGHT;
      $SkipY		= isset($Format["SkipY"]) ? $Format["SkipY"] : OUT_OF_SIGHT;
 
-     /* Calling the ImageFilledPolygon() function over the $Points array will round it */ 	
+     /* Calling the ImageFilledPolygon() function over the $Points array will round it */
      $Backup = $Points;
 
      if ( $Surrounding != NULL ) { $BorderR = $R+$Surrounding; $BorderG = $G+$Surrounding; $BorderB = $B+$Surrounding; }
@@ -200,16 +200,16 @@
      if ( $Value == 0 && $Mode == 1 ) { return(.9); }
      if ( $Value == 0 ) { return(0); }
 
-     if ( $Mode == 1) 
+     if ( $Mode == 1)
       { if ( $Value == 1 ) { return(.9); }; if ( $Value == .1 ) { return(.9); }; if ( $Value == .2 ) { return(.8); }; if ( $Value == .3 ) { return(.8); }; if ( $Value == .4 ) { return(.7); }; if ( $Value == .5 ) { return(.5); }; if ( $Value == .6 ) { return(.8); }; if ( $Value == .7 ) { return(.7); }; if ( $Value == .8 ) { return(.6); }; if ( $Value == .9 ) { return(.9); }; }
 
-     if ( $Mode == 2) 
+     if ( $Mode == 2)
       { if ( $Value == 1 ) { return(.9); }; if ( $Value == .1 ) { return(.1); }; if ( $Value == .2 ) { return(.2); }; if ( $Value == .3 ) { return(.3); }; if ( $Value == .4 ) { return(.4); }; if ( $Value == .5 ) { return(.5); }; if ( $Value == .6 ) { return(.8); }; if ( $Value == .7 ) { return(.7); }; if ( $Value == .8 ) { return(.8); }; if ( $Value == .9 ) { return(.9); }; }
 
-     if ( $Mode == 3) 
+     if ( $Mode == 3)
       { if ( $Value == 1 ) { return(.1); }; if ( $Value == .1 ) { return(.1); }; if ( $Value == .2 ) { return(.2); }; if ( $Value == .3 ) { return(.3); }; if ( $Value == .4 ) { return(.4); }; if ( $Value == .5 ) { return(.9); }; if ( $Value == .6 ) { return(.6); }; if ( $Value == .7 ) { return(.7); }; if ( $Value == .8 ) { return(.4); }; if ( $Value == .9 ) { return(.5); }; }
 
-     if ( $Mode == 4) 
+     if ( $Mode == 4)
       { if ( $Value == 1 ) { return(-1); }; if ( $Value == .1 ) { return(.1); }; if ( $Value == .2 ) { return(.2); }; if ( $Value == .3 ) { return(.3); }; if ( $Value == .4 ) { return(.1); }; if ( $Value == .5 ) { return(-.1); }; if ( $Value == .6 ) { return(.8); }; if ( $Value == .7 ) { return(.1); }; if ( $Value == .8 ) { return(.1); }; if ( $Value == .9 ) { return(.1); }; }
     }
 
@@ -305,7 +305,7 @@
      $YBottom = $Y2-$Radius;
 
      $Step = 360 / (2 * PI * $Radius);
-     $Positions = ""; $Radius--; $MinY = ""; $MaxY = "";
+     $Positions = []; $Radius--; $MinY = ""; $MaxY = "";
      for($i=0;$i<=90;$i=$i+$Step)
       {
        $Xp1 = cos(($i+180)*PI/180) * $Radius + $X1 + $Radius;
@@ -396,7 +396,7 @@
 
      if ( $Alpha < 100 )  { $Drawn[$YTop] = FALSE; }
      if ( $Alpha < 100 )  { $Drawn[$YBottom] = TRUE; }
-     
+
      for($i=0;$i<=90;$i=$i+$Step)
       {
        $Xp1 = cos(($i+180)*PI/180) * $Radius + $X1 + $Radius;
@@ -547,7 +547,7 @@
          $AlphaA = $Alpha * (.5-($X2 - floor($X2)));
          $Color = $this->allocateColor($this->Picture,$R,$G,$B,$AlphaA);
          imageline($this->Picture,floor($X2)+1,ceil($Y1),floor($X2)+1,floor($Y2),$Color);
-        } 
+        }
 
        if ( $Y2 > floor($Y2) )
         {
@@ -684,7 +684,7 @@
          $Q[$ID]["Y"] = $Q[$ID]["Y"] + $P[$j]["Y"] * $C[$j];
         }
        $ID++;
-      }        
+      }
      $Q[$ID]["X"] = $X2; $Q[$ID]["Y"] = $Y2;
 
      if ( !$NoDraw )
@@ -761,7 +761,7 @@
        return(0);
       }
 
-     $Distance = sqrt(($X2-$X1)*($X2-$X1)+($Y2-$Y1)*($Y2-$Y1));  
+     $Distance = sqrt(($X2-$X1)*($X2-$X1)+($Y2-$Y1)*($Y2-$Y1));
      if ( $Distance == 0 ) { return(-1); }
 
      /* Derivative algorithm for overweighted lines, re-route to polygons primitives */
@@ -772,7 +772,7 @@
 
        if ( $Ticks == NULL )
         {
-         $Points   = ""; 
+         $Points   = "";
          $Points[] = cos(deg2rad($Angle-90)) * $Weight + $X1; $Points[] = sin(deg2rad($Angle-90)) * $Weight + $Y1;
          $Points[] = cos(deg2rad($Angle+90)) * $Weight + $X1; $Points[] = sin(deg2rad($Angle+90)) * $Weight + $Y1;
          $Points[] = cos(deg2rad($Angle+90)) * $Weight + $X2; $Points[] = sin(deg2rad($Angle+90)) * $Weight + $Y2;
@@ -787,7 +787,7 @@
            $Xa = (($X2-$X1)/$Distance) * $i + $X1; $Ya = (($Y2-$Y1)/$Distance) * $i + $Y1;
            $Xb = (($X2-$X1)/$Distance) * ($i+$Ticks) + $X1; $Yb = (($Y2-$Y1)/$Distance) * ($i+$Ticks) + $Y1;
 
-           $Points   = ""; 
+           $Points   = "";
            $Points[] = cos(deg2rad($Angle-90)) * $Weight + $Xa; $Points[] = sin(deg2rad($Angle-90)) * $Weight + $Ya;
            $Points[] = cos(deg2rad($Angle+90)) * $Weight + $Xa; $Points[] = sin(deg2rad($Angle+90)) * $Weight + $Ya;
            $Points[] = cos(deg2rad($Angle+90)) * $Weight + $Xb; $Points[] = sin(deg2rad($Angle+90)) * $Weight + $Yb;
@@ -1098,7 +1098,7 @@
             $this->drawFilledRectangle($X1,$Y1,$X2,$Y2,$Color);
             $X1 = $X2+1;
            }
-          $R = $R + $RStep; $G = $G + $GStep; $B = $B + $BStep; 
+          $R = $R + $RStep; $G = $G + $GStep; $B = $B + $BStep;
          }
         if ( $X2 < $EndX && isset($Color)) { $this->drawFilledRectangle($X2,$Y1,$EndX,$Y2,$Color); }
         break;
@@ -1308,7 +1308,7 @@
      $TailX = cos(($Angle-180)*PI/180)*$Size+$X2;
      $TailY = sin(($Angle-180)*PI/180)*$Size+$Y2;
 
-     $Points	= "";
+     $Points	= [];
      $Points[]  = $X2; $Points[]  = $Y2;
      $Points[]	= cos(($Angle-90)*PI/180)*$Size*$Ratio+$TailX; $Points[] = sin(($Angle-90)*PI/180)*$Size*$Ratio+$TailY;
      $Points[]	= cos(($Angle-270)*PI/180)*$Size*$Ratio+$TailX; $Points[] = sin(($Angle-270)*PI/180)*$Size*$Ratio+$TailY;
@@ -1496,7 +1496,7 @@
         }
        else
         $this->drawFilledRectangle($X+1,$Y+1,$X+$InnerWidth,$Y+$Height-1,array("R"=>$R,"G"=>$G,"B"=>$B,"BorderR"=>$BorderR,"BorderG"=>$BorderG,"BorderB"=>$BorderB));
- 
+
        $this->Shadow = $RestoreShadow;
 
        if ( $ShowLabel && $LabelPos == LABEL_POS_LEFT )		{ $this->drawText($X-$Margin,$Y+($Height/2),$Percent."%",array("Align"=>TEXT_ALIGN_MIDDLERIGHT)); }
@@ -1686,7 +1686,7 @@
           {
            $Picture = $Serie["Picture"];
            list($PicWidth,$PicHeight) = $this->getPicInfo($Picture);
-           $PicX = $X+$IconAreaWidth/2; $PicY = $Y+$IconAreaHeight/2; 
+           $PicX = $X+$IconAreaWidth/2; $PicY = $Y+$IconAreaHeight/2;
 
            $this->drawFromPNG($PicX-$PicWidth/2,$PicY-$PicHeight/2,$Picture);
           }
@@ -2005,7 +2005,7 @@
              $Width = ($this->GraphAreaX2 - $this->GraphAreaX1) - $Parameters["Margin"]*2;
 
              if ($Parameters["Rows"] == 0 ) { $Step  = $Width; } else { $Step  = $Width / ($Parameters["Rows"]); }
-             
+
              $MaxBottom = $AxisPos["B"];
              for($i=0;$i<=$Parameters["Rows"];$i++)
               {
@@ -2078,7 +2078,7 @@
              $Width = ($this->GraphAreaX2 - $this->GraphAreaX1) - $Parameters["Margin"]*2;
 
              if ($Parameters["Rows"] == 0 ) { $Step  = $Width; } else { $Step  = $Width / $Parameters["Rows"]; }
-             
+
              $MinTop = $AxisPos["T"];
              for($i=0;$i<=$Parameters["Rows"];$i++)
               {
@@ -2228,7 +2228,7 @@
              $Height = ($this->GraphAreaY2 - $this->GraphAreaY1) - $Parameters["Margin"]*2;
 
              if ($Parameters["Rows"] == 0 ) { $Step  = $Height; } else { $Step   = $Height / $Parameters["Rows"]; }
-             
+
              $MaxRight = $AxisPos["R"];
              for($i=0;$i<=$Parameters["Rows"];$i++)
               {
@@ -2703,9 +2703,9 @@
           {
            if ( $CaptionAlign == CAPTION_LEFT_TOP )
             { $Y = $YPos1 + $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_TOPMIDDLE; }
-           else 
+           else
             { $Y = $YPos2 - $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_BOTTOMMIDDLE; }
-           
+
            $this->drawText($XPos,$Y,$Caption,$CaptionSettings);
           }
 
@@ -2733,9 +2733,9 @@
           {
            if ( $CaptionAlign == CAPTION_LEFT_TOP )
             { $Y = $YPos1 + $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_MIDDLELEFT; }
-           else 
+           else
             { $Y = $YPos2 - $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_MIDDLERIGHT; }
-           
+
            $this->drawText($Y,$XPos,$Caption,$CaptionSettings);
           }
 
@@ -2920,9 +2920,9 @@
           {
            if ( $CaptionAlign == CAPTION_LEFT_TOP )
             { $X = $X1 + $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_MIDDLELEFT; }
-           else 
+           else
             { $X = $X2 - $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_MIDDLERIGHT; }
-           
+
            $this->drawText($X,$YPos,$Caption,$CaptionSettings);
           }
         }
@@ -2950,7 +2950,7 @@
           {
            if ( $CaptionAlign == CAPTION_LEFT_TOP )
             { $Y = $Y1 + $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_TOPMIDDLE; }
-           else 
+           else
             { $Y = $Y2 - $CaptionOffset; $CaptionSettings["Align"] = TEXT_ALIGN_BOTTOMMIDDLE; }
 
            $CaptionSettings["Align"] = TEXT_ALIGN_TOPMIDDLE;
@@ -3149,7 +3149,7 @@
         return(round($Value/1000000,$Format)."m".$Unit);
        elseif (abs($Value) >= 1000)
         return(round($Value/1000,$Format)."k".$Unit);
-       
+
       }
      return($Value.$Unit);
     }
@@ -3205,7 +3205,7 @@
 
          $MinPos = VOID; $MaxPos = VOID;
          foreach($Serie["Data"] as $Key => $Value)
-          { 
+          {
            if ( $Value == $MinValue && $MinPos == VOID ) { $MinPos = $Key; }
            if ( $Value == $MaxValue ) { $MaxPos = $Key; }
           }
@@ -3377,7 +3377,7 @@
            if ( !is_array($PosArray) ) { $Value = $PosArray; $PosArray = ""; $PosArray[0] = $Value; }
            foreach($PosArray as $Key => $Y)
             {
-             if ( $DisplayValues ) 
+             if ( $DisplayValues )
               $this->drawText($X,$Y-$DisplayOffset-$SerieWeight-$BorderSize-$PicOffset,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>TEXT_ALIGN_BOTTOMMIDDLE));
 
              if ( $Y != VOID )
@@ -3401,7 +3401,7 @@
            if ( !is_array($PosArray) ) { $Value = $PosArray; $PosArray = ""; $PosArray[0] = $Value; }
            foreach($PosArray as $Key => $X)
             {
-             if ( $DisplayValues ) 
+             if ( $DisplayValues )
               $this->drawText($X+$DisplayOffset+$SerieWeight+$BorderSize+$PicOffset,$Y,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("Angle"=>270,"R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>TEXT_ALIGN_BOTTOMMIDDLE));
 
              if ( $X != VOID )
@@ -3475,9 +3475,9 @@
            $LastGoodY = NULL; $LastGoodX = NULL; $LastX = 1; $LastY = 1;
            foreach($PosArray as $Key => $Y)
             {
-             if ( $DisplayValues ) 
+             if ( $DisplayValues )
               $this->drawText($X,$Y-$DisplayOffset,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>TEXT_ALIGN_BOTTOMMIDDLE));
-	
+
              if ( $RecordImageMap && $Y != VOID ) { $this->addToImageMap("CIRCLE",floor($X).",".floor($Y).",".$ImageMapPlotSize,$this->toHTMLColor($R,$G,$B),$SerieDescription,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit)); }
 
              if ( $Y == VOID && $LastY != NULL )
@@ -3507,7 +3507,7 @@
            $LastGoodY = NULL; $LastGoodX = NULL; $LastX = 1; $LastY = 1;
            foreach($PosArray as $Key => $X)
             {
-             if ( $DisplayValues ) 
+             if ( $DisplayValues )
               $this->drawText($X+$DisplayOffset,$Y,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("Angle"=>270,"R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>TEXT_ALIGN_BOTTOMMIDDLE));
 
              if ( $RecordImageMap && $X != VOID ) { $this->addToImageMap("CIRCLE",floor($X).",".floor($Y).",".$ImageMapPlotSize,$this->toHTMLColor($R,$G,$B),$SerieDescription,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit)); }
@@ -3589,7 +3589,7 @@
            if ( !is_array($PosArray) ) { $Value = $PosArray; $PosArray = ""; $PosArray[0] = $Value; }
            foreach($PosArray as $Key => $Y)
             {
-             if ( $DisplayValues ) 
+             if ( $DisplayValues )
               $this->drawText($X,$Y-$DisplayOffset,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>TEXT_ALIGN_BOTTOMMIDDLE));
 
              if ( $Y == VOID )
@@ -3652,7 +3652,7 @@
            if ( !is_array($PosArray) ) { $Value = $PosArray; $PosArray = ""; $PosArray[0] = $Value; }
            foreach($PosArray as $Key => $X)
             {
-             if ( $DisplayValues ) 
+             if ( $DisplayValues )
               $this->drawText($X+$DisplayOffset,$Y,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("Angle"=>270,"R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>TEXT_ALIGN_BOTTOMMIDDLE));
 
              if ( $X == VOID )
@@ -3769,7 +3769,7 @@
            $LastGoodY = NULL; $LastGoodX = NULL;
            foreach($PosArray as $Key => $Y)
             {
-             if ( $DisplayValues && $Serie["Data"][$Key] != VOID ) 
+             if ( $DisplayValues && $Serie["Data"][$Key] != VOID )
               {
                if ( $Serie["Data"][$Key] > 0 ) { $Align = TEXT_ALIGN_BOTTOMMIDDLE; $Offset = $DisplayOffset; } else { $Align = TEXT_ALIGN_TOPMIDDLE; $Offset = -$DisplayOffset; }
                $this->drawText($X,$Y-$Offset-$Weight,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>$Align));
@@ -3799,7 +3799,7 @@
            $LastGoodY = NULL; $LastGoodX = NULL;
            foreach($PosArray as $Key => $X)
             {
-             if ( $DisplayValues && $Serie["Data"][$Key] != VOID ) 
+             if ( $DisplayValues && $Serie["Data"][$Key] != VOID )
               { $this->drawText($X+$DisplayOffset+$Weight,$Y,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("Angle"=>270,"R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>TEXT_ALIGN_BOTTOMMIDDLE)); }
 
              if ( $RecordImageMap && $X != VOID ) { $this->addToImageMap("CIRCLE",floor($X).",".floor($Y).",".$ImageMapPlotSize,$this->toHTMLColor($R,$G,$B),$SerieDescription,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit)); }
@@ -3966,7 +3966,7 @@
            $LastGoodY = NULL; $LastGoodX = NULL; $Init = FALSE;
            foreach($PosArray as $Key => $Y)
             {
-             if ( $DisplayValues && $Serie["Data"][$Key] != VOID ) 
+             if ( $DisplayValues && $Serie["Data"][$Key] != VOID )
               {
                if ( $Y <= $LastY ) { $Align = TEXT_ALIGN_BOTTOMMIDDLE; $Offset = $DisplayOffset; } else { $Align = TEXT_ALIGN_TOPMIDDLE; $Offset = -$DisplayOffset; }
                $this->drawText($X,$Y-$Offset-$Weight,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>$Align));
@@ -3986,7 +3986,7 @@
               }
 
              if ( $Y != VOID && $LastY == NULL && $LastGoodY != NULL && !$BreakVoid )
-              { 
+              {
                if ( $ReCenter )
                 {
                  $this->drawLine($LastGoodX+$XStep,$LastGoodY,$X,$LastGoodY,$BreakSettings);
@@ -4030,7 +4030,7 @@
            $LastGoodY = NULL; $LastGoodX = NULL; $Init = FALSE;
            foreach($PosArray as $Key => $X)
             {
-             if ( $DisplayValues && $Serie["Data"][$Key] != VOID ) 
+             if ( $DisplayValues && $Serie["Data"][$Key] != VOID )
               {
                if ( $X >= $LastX ) { $Align = TEXT_ALIGN_MIDDLELEFT; $Offset = $DisplayOffset; } else { $Align = TEXT_ALIGN_MIDDLERIGHT; $Offset = -$DisplayOffset; }
                $this->drawText($X+$Offset+$Weight,$Y,$this->scaleFormat($Serie["Data"][$Key],$Mode,$Format,$Unit),array("R"=>$DisplayR,"G"=>$DisplayG,"B"=>$DisplayB,"Align"=>$Align));
@@ -4267,7 +4267,7 @@
           {
            if ( $YZero > $this->GraphAreaY2-1 ) { $YZero = $this->GraphAreaY2-1; }
 
-           $Areas = ""; $AreaID = 0; 
+           $Areas = ""; $AreaID = 0;
            $Areas[$AreaID][] = $this->GraphAreaX1 + $XMargin;
            if ( $AroundZero ) { $Areas[$AreaID][] = $YZero; } else { $Areas[$AreaID][] = $this->GraphAreaY2-1; }
 
@@ -4325,7 +4325,7 @@
                  else
                   { $ShadowArea[$Key][] = $Value + $this->ShadowY; }
                 }
-              }              
+              }
 
              foreach($ShadowArea as $Key => $Points)
               $this->drawPolygonChart($Points,array("R"=>$this->ShadowR,"G"=>$this->ShadowG,"B"=>$this->ShadowB,"Alpha"=>$this->Shadowa));
@@ -4342,7 +4342,7 @@
            if ( $YZero < $this->GraphAreaX1+1 ) { $YZero = $this->GraphAreaX1+1; }
            if ( $YZero > $this->GraphAreaX2-1 ) { $YZero = $this->GraphAreaX2-1; }
 
-           $Areas = ""; $AreaID = 0; 
+           $Areas = ""; $AreaID = 0;
            if ( $AroundZero ) { $Areas[$AreaID][] = $YZero; } else { $Areas[$AreaID][] = $this->GraphAreaX1+1; }
            $Areas[$AreaID][] = $this->GraphAreaY1 + $XMargin;
 
@@ -4401,7 +4401,7 @@
                  else
                   { $ShadowArea[$Key][] = $Value + $this->ShadowY; }
                 }
-              }              
+              }
 
              foreach($ShadowArea as $Key => $Points)
               $this->drawPolygonChart($Points,array("R"=>$this->ShadowR,"G"=>$this->ShadowG,"B"=>$this->ShadowB,"Alpha"=>$this->Shadowa));
@@ -4635,12 +4635,12 @@
            if ( $YZero > $this->GraphAreaX2-1 ) { $YZero = $this->GraphAreaX2-1; }
 
            if ( $XDivs == 0 ) { $YStep = 0; } else { $YStep = ($this->GraphAreaY2-$this->GraphAreaY1-$XMargin*2)/$XDivs; }
-           
+
            $Y = $this->GraphAreaY1 + $XMargin;
 
            if ( $AroundZero ) { $X1 = $YZero; } else { $X1 = $this->GraphAreaX1+1; }
            if ( $XDivs == 0 ) { $YSize = ($this->GraphAreaY2-$this->GraphAreaY1)/($SeriesCount+$Interleave); } else { $YSize   = ($YStep / ($SeriesCount+$Interleave) ); }
-           
+
            $YOffset = -($YSize*$SeriesCount)/2 + $CurrentSerie * $YSize;
            if ( $Y + $YOffset <= $this->GraphAreaY1 ) { $YOffset = $this->GraphAreaY1 - $Y + 1 ; }
 
@@ -4727,7 +4727,7 @@
                   }
                 }
 
-               if ( $DisplayValues && $Serie["Data"][$Key] != VOID ) 
+               if ( $DisplayValues && $Serie["Data"][$Key] != VOID )
                 {
                  if ( $DisplayShadow ) { $this->Shadow = TRUE; }
 
@@ -5070,7 +5070,7 @@
 
            $OverallOffset[$Key][$Sign] = $OverallOffset[$Key][$Sign] + abs($Value);
           }
-        } 
+        }
       }
      $SerieOrder = array_reverse($SerieOrder);
 
@@ -5183,7 +5183,7 @@
    /* Returns a random color */
    function getRandomColor($Alpha=100)
     { return(array("R"=>rand(0,255),"G"=>rand(0,255),"B"=>rand(0,255),"Alpha"=>$Alpha)); }
- 
+
    /* Validate a palette */
    function validatePalette($Colors,$Surrounding=NULL)
     {
@@ -5281,7 +5281,7 @@
           {
            if ( $Caption )
             {
-             if ( $CaptionLine ) 
+             if ( $CaptionLine )
               {
                $StartX = floor($this->GraphAreaX1-$CaptionWidth+$XMargin-$CaptionMargin);
                $EndX   = floor($this->GraphAreaX1-$CaptionMargin+$XMargin);
@@ -5375,7 +5375,7 @@
             {
              $StartY = floor($this->GraphAreaY1-$CaptionWidth+$XMargin-$CaptionMargin);
              $EndY   = floor($this->GraphAreaY1-$CaptionMargin+$XMargin);
-             if ( $CaptionLine ) 
+             if ( $CaptionLine )
               {
                $CaptionSettings = array("R"=>$R,"G"=>$G,"B"=>$B,"Alpha"=>$Alpha,"Ticks"=>$Ticks,"Weight"=>$Weight);
                if ( $CaptionBox ) { $this->drawFilledRectangle($XPos,$StartY,$XPos+$CaptionHeight,$EndY,array("R"=>$CaptionFillR,"G"=>$CaptionFillG,"B"=>$CaptionFillB,"BorderR"=>$CaptionBorderR,"BorderG"=>$CaptionBorderG,"BorderB"=>$CaptionBorderB,"Alpha"=>$CaptionFillAlpha)); }
@@ -5446,7 +5446,7 @@
 
                  $this->drawGradientArea($TopX,$LastY,$BottomX,$Y,DIRECTION_VERTICAL,$GradientSettings);
                 }
-               elseif ( !$ShadedSlopeBox || $LastColor == NULL ) 
+               elseif ( !$ShadedSlopeBox || $LastColor == NULL )
                 $this->drawFilledRectangle($TopX,floor($LastY),$BottomX,floor($Y),$Color);
 
                $LastColor = $Color;
@@ -5982,7 +5982,7 @@
       {
        $Pos = ""; $Pos[]=$X-$PlotSize; $Pos[]=$Y; $Pos[]=$X; $Pos[]=$Y-$PlotSize; $Pos[]=$X+$PlotSize; $Pos[]=$Y; $Pos[]=$X; $Pos[]=$Y+$PlotSize;
        $this->drawPolygon($Pos,array("NoFill"=>TRUE,"BorderR"=>$R,"BorderG"=>$G,"BorderB"=>$B,"BorderAlpha"=>$Alpha));
-      }      
+      }
      elseif ( $Shape == SERIE_SHAPE_FILLEDDIAMOND )
       {
        if ( $PlotBorder )
@@ -5993,7 +5993,7 @@
 
        $Pos = ""; $Pos[]=$X-$PlotSize; $Pos[]=$Y; $Pos[]=$X; $Pos[]=$Y-$PlotSize; $Pos[]=$X+$PlotSize; $Pos[]=$Y; $Pos[]=$X; $Pos[]=$Y+$PlotSize;
        $this->drawPolygon($Pos,array("R"=>$R,"G"=>$G,"B"=>$B,"Alpha"=>$Alpha));
-      }      
+      }
     }
 
    function drawPolygonChart($Points,$Format="")
@@ -6063,7 +6063,7 @@
      $DefaultColor = $this->allocateColor($this->Picture,$R,$G,$B,$Alpha);
      $DebugLine = 0; $DebugColor = $this->allocateColor($this->Picture,255,0,0,100);
 
-     $MinY = floor($MinY); $MaxY = floor($MaxY); $YStep = 1; 
+     $MinY = floor($MinY); $MaxY = floor($MaxY); $YStep = 1;
 
      if ( !$NoFill )
       {

--- a/pchart/class/pPie.class.php
+++ b/pchart/class/pPie.class.php
@@ -100,7 +100,7 @@
      if ( $SerieSum == 0 ) { return(PIE_SUMISNULL); }
 
      /* Dump the real number of data to draw */
-     $Values = "";
+     $Values = [];
      foreach ($Data["Series"][$DataSerie]["Data"] as $Key => $Value)
       { if ($Value != 0) { $Values[] = $Value; } }
 
@@ -140,7 +140,7 @@
           { $Settings["BorderR"] = $BorderR; $Settings["BorderG"] = $BorderG; $Settings["BorderB"] = $BorderB; }
         }
 
-       $Plots = "";
+       $Plots = [];
        $EndAngle = $Offset+($Value*$ScaleFactor); if ( $EndAngle > 360 ) { $EndAngle = 360; }
 
        $Angle = ($EndAngle - $Offset)/2 + $Offset;
@@ -228,7 +228,7 @@
            $Yc = sin(($i-90)*PI/180) * $Radius + $Y;
 
            if ( $FirstPoint ) { $this->pChartObject->drawLine($Xc,$Yc,$X0,$Y0,$Settings); } { $FirstPoint = FALSE; }
-  
+
            $this->pChartObject->drawAntialiasPixel($Xc,$Yc,$Settings);
           }
          $this->pChartObject->drawLine($Xc,$Yc,$X0,$Y0,$Settings);
@@ -251,7 +251,7 @@
            else
             $this->writePieLabel($Xc,$Yc,$Label,$Angle,$Settings,FALSE);
           }
-  
+
          $Offset = $i + $DataGapAngle; $ID++;
         }
       }
@@ -452,7 +452,7 @@
          $Settings = $SliceColors[$SliceID];
          if ( $Border )
           { $Settings["R"]+= 30; $Settings["G"]+= 30; $Settings["B"]+= 30;; }
-  
+
          if ( isset($SliceAngle[$SliceID][1]) ) /* Empty error handling */
           {
            $Angle = $SliceAngle[$SliceID][1];
@@ -481,7 +481,7 @@
          $this->pChartObject->drawLine($Plots[2],$Plots[3],$Plots[2],$Plots[3]- $SliceHeight,array("R"=>$Settings["R"],"G"=>$Settings["G"],"B"=>$Settings["B"]));
          $Border = "";
          $Border[] = $Plots[0]; $Border[] = $Plots[1]; $Border[] = $Plots[0]; $Border[] = $Plots[1] - $SliceHeight;
-         $Border[] = $Plots[2]; $Border[] = $Plots[3] - $SliceHeight; $Border[] = $Plots[2]; $Border[] = $Plots[3]; 
+         $Border[] = $Plots[2]; $Border[] = $Plots[3] - $SliceHeight; $Border[] = $Plots[2]; $Border[] = $Plots[3];
          $this->pChartObject->drawPolygon($Border,$Settings);
         }
       }
@@ -498,7 +498,7 @@
 
          $Border = "";
          $Border[] = $Plots[0]; $Border[] = $Plots[1]; $Border[] = $Plots[0]; $Border[] = $Plots[1] - $SliceHeight;
-         $Border[] = $Plots[count($Plots)-2]; $Border[] = $Plots[count($Plots)-1] - $SliceHeight; $Border[] = $Plots[count($Plots)-2]; $Border[] = $Plots[count($Plots)-1]; 
+         $Border[] = $Plots[count($Plots)-2]; $Border[] = $Plots[count($Plots)-1] - $SliceHeight; $Border[] = $Plots[count($Plots)-2]; $Border[] = $Plots[count($Plots)-1];
          $this->pChartObject->drawPolygon($Border,$Settings);
         }
       }
@@ -528,7 +528,7 @@
          $Settings = $SliceColors[$SliceID];
          if ( $Border )
           { $Settings["R"]+= 30; $Settings["G"]+= 30; $Settings["B"]+= 30; }
-  
+
          if ( isset($SliceAngle[$SliceID][1]) ) /* Empty error handling */
           {
            $Angle = $SliceAngle[$SliceID][1];
@@ -615,7 +615,7 @@
            $Yc = sin(($i-90)*PI/180) * $Radius*$SkewFactor + $Y - $SliceHeight;
 
            if ( $FirstPoint ) { $this->pChartObject->drawLine($Xc,$Yc,$X0,$Y0,$Settings); } { $FirstPoint = FALSE; }
-  
+
            $this->pChartObject->drawAntialiasPixel($Xc,$Yc,$Settings);
            if ($i < 270 && $i > 90 ) { $this->pChartObject->drawAntialiasPixel($Xc,$Yc+$SliceHeight,$Settings); }
           }
@@ -820,7 +820,7 @@
        $YTop    = $Y2 - $Height/2 - 2;
        $YBottom = $Y2 + $Height/2 + 2;
 
-       if ( $this->LabelPos != "" )
+       if ( $this->LabelPos != [] )
         {
          $Done = FALSE;
          foreach($this->LabelPos as $Key => $Settings)
@@ -842,7 +842,7 @@
        $LabelSettings = array("YTop"=>$YTop,"YBottom"=>$YBottom,"Label"=>$Label,"Angle"=>$Angle,"X1"=>$X,"Y1"=>$Y,"X2"=>$X2,"Y2"=>$Y2);
        if ( $Angle <= 180 ) { $LabelSettings["X3"] = $Xc+$Radius+$LabelOffset; }
        if ( $Angle > 180 )  { $LabelSettings["X3"] = $Xc-$Radius-$LabelOffset; }
-       $this->LabelPos[] = $LabelSettings;
+       $this->LabelPos = $LabelSettings;
       }
     }
 
@@ -859,7 +859,7 @@
    /* Internally used to write the re-computed labels */
    function writeShiftedLabels()
     {
-     if ( $this->LabelPos == "" ) { return(0); }
+     if ( $this->LabelPos == [] ) { return(0); }
      foreach($this->LabelPos as $Key => $Settings)
       {
        $X1 = $Settings["X1"]; $Y1 = $Settings["Y1"];
@@ -1400,7 +1400,7 @@
       {
        $Settings = $SliceColors[$SliceID];  $Settings["NoBorder"] = TRUE;
        $Settings["R"] = $Settings["R"]+$Cf*2; $Settings["G"] = $Settings["G"]+$Cf*2; $Settings["B"] = $Settings["B"]+$Cf*2;
- 
+
        $this->pChartObject->drawPolygon($Plots["TopPoly"],$Settings);
 
        if ( $RecordImageMap ) { $this->pChartObject->addToImageMap("POLY",$this->arraySerialize($Plots["TopPoly"]),$this->pChartObject->toHTMLColor($Settings["R"],$Settings["G"],$Settings["B"]),$Data["Series"][$Data["Abscissa"]]["Data"][$SliceID],$Data["Series"][$DataSerie]["Data"][count($Slices)-$SliceID-1]); }
@@ -1475,7 +1475,9 @@
   /* Remove unused series & values */
   function clean0Values($Data,$Palette,$DataSerie,$AbscissaSerie)
    {
-    $NewPalette = ""; $NewData = ""; $NewAbscissa = "";
+    $NewPalette = [];
+    $NewData = [];
+    $NewAbscissa = [];
 
     /* Remove unused series */
     foreach($Data["Series"] as $SerieName => $SerieSettings)


### PR DESCRIPTION
Most errors come from arrays initialized as strings.
```
// Before
$array = "";
// After
$array = [];
```